### PR TITLE
Optionally support a full path to profile script

### DIFF
--- a/scripts/vr_companion.py
+++ b/scripts/vr_companion.py
@@ -2417,7 +2417,9 @@ def selectProfile():
     
     # apply profile    
     diagnostics.watch(profile)
-    with open('scripts/profiles/' + profile + '.py') as f:
+    if not profile.endswith(".py"):
+        profile = 'scripts/profiles/' + profile + '.py'
+    with open(profile) as f:
         exec(f.read())
             
 # initialization of state and constants


### PR DESCRIPTION
This is a simple patch to optionally support a full path to a profile python script in addition to profile names. Because this code is after `if showDialog:`, this only applies to usage with `FreePIE.Console.exe` and these paths will never be written to `vr_companion.json` as a profile name.

I found this very useful when editing profiles from VS Code: I made a `.vscode/tasks.json` to running the open profile script as a "build" task (the path to the open file is `${file}` below and passed as an argument to `FreePIE.Console.exe`). Annoyingly there's no UI for this in VS Code, you have to use the command palate (and the ▶️ run button can't easily be integrated with, it's for debugging and requires a VS Code extension to extend). The output from the task runs in an embedded terminal window and you can terminate it from there.

If you want I can send a PR for this, but I thought the simple patch to support a full path to a profile would be more generally useful to everyone.

`.vscode/tasks.json` config:
```json
{
    "version": "2.0.0",
    "tasks": [
        {
            "label": "Run profile",
            "type": "process",
            "command": "FreePIE.Console.exe",
            "args": [
                ".\\scripts\\vr_companion.py",
                "${file}"
            ],
            "problemMatcher": [],
            "group": {
                "kind": "build",
                "isDefault": true
            },
            "presentation": {
              "reveal": "always",
              "panel": "dedicated"
            }
        }
    ]
}
```